### PR TITLE
Bump to gnuradio 3.10/3.11

### DIFF
--- a/apps/test.grc
+++ b/apps/test.grc
@@ -137,7 +137,7 @@ blocks:
     showports: 'False'
     showrf: 'False'
     type: complex
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/grc/lora_sdr_data_source_sim.block.yml
+++ b/grc/lora_sdr_data_source_sim.block.yml
@@ -25,13 +25,6 @@ parameters:
     dtype: bool
     default: False
 
-inputs:
-
-assert:
-  - ${ pay_len > 1 }
-  - ${ n_frames > 1}
-  - ${ mean >1}
-
 outputs:
   - domain: message
     id: msg

--- a/grc/lora_sdr_fft_demod.block.yml
+++ b/grc/lora_sdr_fft_demod.block.yml
@@ -24,9 +24,6 @@ inputs:
     dtype: complex
     vlen: ${ 2**sf }
 
-assert:
-  - ${ sf ==7 or sf == 8 or sf ==9 or sf == 10 or sf == 11 or sf ==12 }
-
 outputs:
   - domain: stream
     dtype: int

--- a/grc/lora_sdr_frame_sender.block.yml
+++ b/grc/lora_sdr_frame_sender.block.yml
@@ -52,29 +52,23 @@ parameters:
   label: Has_crc
   dtype: bool
   default: "False"
-  optional: true
 - id: pay_len
   label: Pay_len
   dtype: int
-  optional: true
 - id: cr
   label: Cr
   dtype: int
-  optional: true
 - id: impl_head
   label: Impl_head
   dtype: bool
-  optional: true
 - id: sync_words
   label: Sync words
   dtype: int_vector
   default: [8, 16]
-  optional: true
 - id: input_data
   label: Input string
   dtype: string
   default: ""
-  optional: true
 
 asserts:
   - ${ sf ==7 or sf == 8 or sf ==9 or sf == 10 or sf == 11 or sf ==12 }

--- a/grc/lora_sdr_frame_sync.block.yml
+++ b/grc/lora_sdr_frame_sync.block.yml
@@ -28,8 +28,6 @@ inputs:
     dtype: complex
   - domain: message
     id: frame_info
-assert:
-  - ${ sf ==7 or sf == 8 or sf ==9 or sf == 10 or sf == 11 or sf ==12 }
 
 outputs:
   - domain: stream

--- a/grc/lora_sdr_gray_decode.block.yml
+++ b/grc/lora_sdr_gray_decode.block.yml
@@ -14,9 +14,6 @@ inputs:
   - domain: stream
     dtype: int
 
-assert:
-  - ${ sf ==7 or sf == 8 or sf ==9 or sf == 10 or sf == 11 or sf ==12 }
-
 outputs:
   - domain: stream
     dtype: int

--- a/grc/lora_sdr_hier_tx.block.yml
+++ b/grc/lora_sdr_hier_tx.block.yml
@@ -81,7 +81,6 @@ asserts:
 #      * dtype (e.g. int, float, complex, byte, short, xxx_vector, ...)
 #      * vlen (optional - data stream vector length. Default is 1)
 #      * optional (optional - set to 1 for optional inputs. Default is 0)
-inputs:
 
 outputs:
   - domain: stream


### PR DESCRIPTION
This updates the module to gnuradio 3.10/3.11 and fixes some errors in the yml files (missing inputs and removed ignored asserts).