### PR TITLE
Fixes and compatibility changes for gnuradio 3.10 and newer

### DIFF
--- a/apps/test.grc
+++ b/apps/test.grc
@@ -137,7 +137,7 @@ blocks:
     showports: 'False'
     showrf: 'False'
     type: complex
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/grc/lora_sdr_data_source_sim.block.yml
+++ b/grc/lora_sdr_data_source_sim.block.yml
@@ -25,13 +25,6 @@ parameters:
     dtype: bool
     default: False
 
-inputs:
-
-assert:
-  - ${ pay_len > 1 }
-  - ${ n_frames > 1}
-  - ${ mean >1}
-
 outputs:
   - domain: message
     id: msg

--- a/grc/lora_sdr_fft_demod.block.yml
+++ b/grc/lora_sdr_fft_demod.block.yml
@@ -24,9 +24,6 @@ inputs:
     dtype: complex
     vlen: ${ 2**sf }
 
-assert:
-  - ${ sf ==7 or sf == 8 or sf ==9 or sf == 10 or sf == 11 or sf ==12 }
-
 outputs:
   - domain: stream
     dtype: int

--- a/grc/lora_sdr_frame_sender.block.yml
+++ b/grc/lora_sdr_frame_sender.block.yml
@@ -52,29 +52,23 @@ parameters:
   label: Has_crc
   dtype: bool
   default: "False"
-  optional: true
 - id: pay_len
   label: Pay_len
   dtype: int
-  optional: true
 - id: cr
   label: Cr
   dtype: int
-  optional: true
 - id: impl_head
   label: Impl_head
   dtype: bool
-  optional: true
 - id: sync_words
   label: Sync words
   dtype: int_vector
   default: [8, 16]
-  optional: true
 - id: input_data
   label: Input string
   dtype: string
   default: ""
-  optional: true
 
 asserts:
   - ${ sf ==7 or sf == 8 or sf ==9 or sf == 10 or sf == 11 or sf ==12 }

--- a/grc/lora_sdr_frame_sync.block.yml
+++ b/grc/lora_sdr_frame_sync.block.yml
@@ -28,8 +28,6 @@ inputs:
     dtype: complex
   - domain: message
     id: frame_info
-assert:
-  - ${ sf ==7 or sf == 8 or sf ==9 or sf == 10 or sf == 11 or sf ==12 }
 
 outputs:
   - domain: stream

--- a/grc/lora_sdr_gray_decode.block.yml
+++ b/grc/lora_sdr_gray_decode.block.yml
@@ -14,9 +14,6 @@ inputs:
   - domain: stream
     dtype: int
 
-assert:
-  - ${ sf ==7 or sf == 8 or sf ==9 or sf == 10 or sf == 11 or sf ==12 }
-
 outputs:
   - domain: stream
     dtype: int

--- a/grc/lora_sdr_hier_tx.block.yml
+++ b/grc/lora_sdr_hier_tx.block.yml
@@ -81,7 +81,6 @@ asserts:
 #      * dtype (e.g. int, float, complex, byte, short, xxx_vector, ...)
 #      * vlen (optional - data stream vector length. Default is 1)
 #      * optional (optional - set to 1 for optional inputs. Default is 0)
-inputs:
 
 outputs:
   - domain: stream

--- a/python/bindings/RH_RF95_header_python.cc
+++ b/python/bindings/RH_RF95_header_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_RH_RF95_header(py::module& m)
 {
 
-    using RH_RF95_header    = gr::lora_sdr::RH_RF95_header;
+    using RH_RF95_header    = ::gr::lora_sdr::RH_RF95_header;
 
 
-    py::class_<RH_RF95_header,
+    py::class_<RH_RF95_header, gr::block, gr::basic_block,
         std::shared_ptr<RH_RF95_header>>(m, "RH_RF95_header", D(RH_RF95_header))
 
         .def(py::init(&RH_RF95_header::make),

--- a/python/bindings/add_crc_python.cc
+++ b/python/bindings/add_crc_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_add_crc(py::module& m)
 {
 
-    using add_crc    = gr::lora_sdr::add_crc;
+    using add_crc    = ::gr::lora_sdr::add_crc;
 
 
-    py::class_<add_crc,
+    py::class_<add_crc, gr::block, gr::basic_block,
         std::shared_ptr<add_crc>>(m, "add_crc", D(add_crc))
 
         .def(py::init(&add_crc::make),

--- a/python/bindings/bind_oot_file.py
+++ b/python/bindings/bind_oot_file.py
@@ -4,22 +4,23 @@ import os
 from gnuradio.bindtool import BindingGenerator
 import pathlib
 import sys
+import tempfile
 
 parser = argparse.ArgumentParser(description='Bind a GR Out of Tree Block')
 parser.add_argument('--module', type=str,
                     help='Name of gr module containing file to bind (e.g. fft digital analog)')
 
-parser.add_argument('--output_dir', default='/tmp',
+parser.add_argument('--output_dir', default=tempfile.gettempdir(),
                     help='Output directory of generated bindings')
 parser.add_argument('--prefix', help='Prefix of Installed GNU Radio')
 parser.add_argument('--src', help='Directory of gnuradio source tree',
-                    default=os.path.dirname(os.path.abspath(__file__))+'/../../..')
+                    default=os.path.dirname(os.path.abspath(__file__)) + '/../../..')
 
 parser.add_argument(
     '--filename', help="File to be parsed")
 
 parser.add_argument(
-    '--defines', help='Set additional defines for precompiler',default=(), nargs='*')
+    '--defines', help='Set additional defines for precompiler', default=(), nargs='*')
 parser.add_argument(
     '--include', help='Additional Include Dirs, separated', default=(), nargs='*')
 

--- a/python/bindings/crc_verif_python.cc
+++ b/python/bindings/crc_verif_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_crc_verif(py::module& m)
 {
 
-    using crc_verif    = gr::lora_sdr::crc_verif;
+    using crc_verif    = ::gr::lora_sdr::crc_verif;
 
 
-    py::class_<crc_verif,
+    py::class_<crc_verif, gr::block, gr::basic_block,
         std::shared_ptr<crc_verif>>(m, "crc_verif", D(crc_verif))
 
         .def(py::init(&crc_verif::make),

--- a/python/bindings/data_source_python.cc
+++ b/python/bindings/data_source_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_data_source(py::module& m)
 {
 
-    using data_source    = gr::lora_sdr::data_source;
+    using data_source    = ::gr::lora_sdr::data_source;
 
 
-    py::class_<data_source,
+    py::class_<data_source, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<data_source>>(m, "data_source", D(data_source))
 
         .def(py::init(&data_source::make),

--- a/python/bindings/data_source_sim_python.cc
+++ b/python/bindings/data_source_sim_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_data_source_sim(py::module& m)
 {
 
-    using data_source_sim    = gr::lora_sdr::data_source_sim;
+    using data_source_sim    = ::gr::lora_sdr::data_source_sim;
 
 
-    py::class_<data_source_sim,
+    py::class_<data_source_sim, gr::block, gr::basic_block,
         std::shared_ptr<data_source_sim>>(m, "data_source_sim", D(data_source_sim))
 
         .def(py::init(&data_source_sim::make),

--- a/python/bindings/deinterleaver_python.cc
+++ b/python/bindings/deinterleaver_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_deinterleaver(py::module& m)
 {
 
-    using deinterleaver    = gr::lora_sdr::deinterleaver;
+    using deinterleaver    = ::gr::lora_sdr::deinterleaver;
 
 
-    py::class_<deinterleaver,
+    py::class_<deinterleaver, gr::block, gr::basic_block,
         std::shared_ptr<deinterleaver>>(m, "deinterleaver", D(deinterleaver))
 
         .def(py::init(&deinterleaver::make),

--- a/python/bindings/dewhitening_python.cc
+++ b/python/bindings/dewhitening_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_dewhitening(py::module& m)
 {
 
-    using dewhitening    = gr::lora_sdr::dewhitening;
+    using dewhitening    = ::gr::lora_sdr::dewhitening;
 
 
-    py::class_<dewhitening,
+    py::class_<dewhitening, gr::block, gr::basic_block,
         std::shared_ptr<dewhitening>>(m, "dewhitening", D(dewhitening))
 
         .def(py::init(&dewhitening::make),

--- a/python/bindings/docstrings/RH_RF95_header_pydoc_template.h
+++ b/python/bindings/docstrings/RH_RF95_header_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_RH_RF95_header = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_RH_RF95_header_RH_RF95_header = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_RH_RF95_header_make = R"doc()doc";

--- a/python/bindings/docstrings/add_crc_pydoc_template.h
+++ b/python/bindings/docstrings/add_crc_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_add_crc = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_add_crc_add_crc = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_add_crc_make = R"doc()doc";

--- a/python/bindings/docstrings/crc_verif_pydoc_template.h
+++ b/python/bindings/docstrings/crc_verif_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_crc_verif = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_crc_verif_crc_verif = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_crc_verif_make = R"doc()doc";

--- a/python/bindings/docstrings/data_source_pydoc_template.h
+++ b/python/bindings/docstrings/data_source_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_data_source = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_data_source_data_source = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_data_source_make = R"doc()doc";

--- a/python/bindings/docstrings/data_source_sim_pydoc_template.h
+++ b/python/bindings/docstrings/data_source_sim_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_data_source_sim = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_data_source_sim_data_source_sim = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_data_source_sim_make = R"doc()doc";

--- a/python/bindings/docstrings/deinterleaver_pydoc_template.h
+++ b/python/bindings/docstrings/deinterleaver_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_deinterleaver = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_deinterleaver_deinterleaver = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_deinterleaver_make = R"doc()doc";

--- a/python/bindings/docstrings/dewhitening_pydoc_template.h
+++ b/python/bindings/docstrings/dewhitening_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_dewhitening = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_dewhitening_dewhitening = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_dewhitening_make = R"doc()doc";

--- a/python/bindings/docstrings/err_measures_pydoc_template.h
+++ b/python/bindings/docstrings/err_measures_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_err_measures = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_err_measures_err_measures = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_err_measures_make = R"doc()doc";

--- a/python/bindings/docstrings/fft_demod_pydoc_template.h
+++ b/python/bindings/docstrings/fft_demod_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_fft_demod = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_fft_demod_fft_demod = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_fft_demod_make = R"doc()doc";

--- a/python/bindings/docstrings/frame_detector_sequence_pydoc_template.h
+++ b/python/bindings/docstrings/frame_detector_sequence_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_frame_detector_sequence = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_frame_detector_sequence_frame_detector_sequence = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_frame_detector_sequence_make = R"doc()doc";

--- a/python/bindings/docstrings/frame_detector_threshold_pydoc_template.h
+++ b/python/bindings/docstrings/frame_detector_threshold_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_frame_detector_threshold = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_frame_detector_threshold_frame_detector_threshold = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_frame_detector_threshold_make = R"doc()doc";

--- a/python/bindings/docstrings/frame_detector_timeout_pydoc_template.h
+++ b/python/bindings/docstrings/frame_detector_timeout_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_frame_detector_timeout = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_frame_detector_timeout_frame_detector_timeout = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_frame_detector_timeout_make = R"doc()doc";

--- a/python/bindings/docstrings/frame_src_pydoc_template.h
+++ b/python/bindings/docstrings/frame_src_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_frame_src = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_frame_src_frame_src = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_frame_src_make = R"doc()doc";

--- a/python/bindings/docstrings/frame_sync_pydoc_template.h
+++ b/python/bindings/docstrings/frame_sync_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_frame_sync = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_frame_sync_frame_sync = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_frame_sync_make = R"doc()doc";

--- a/python/bindings/docstrings/gray_decode_pydoc_template.h
+++ b/python/bindings/docstrings/gray_decode_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_gray_decode = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_gray_decode_gray_decode = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_gray_decode_make = R"doc()doc";

--- a/python/bindings/docstrings/gray_enc_pydoc_template.h
+++ b/python/bindings/docstrings/gray_enc_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_gray_enc = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_gray_enc_gray_enc = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_gray_enc_make = R"doc()doc";

--- a/python/bindings/docstrings/hamming_dec_pydoc_template.h
+++ b/python/bindings/docstrings/hamming_dec_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_hamming_dec = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_hamming_dec_hamming_dec = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_hamming_dec_make = R"doc()doc";

--- a/python/bindings/docstrings/hamming_enc_pydoc_template.h
+++ b/python/bindings/docstrings/hamming_enc_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_hamming_enc = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_hamming_enc_hamming_enc = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_hamming_enc_make = R"doc()doc";

--- a/python/bindings/docstrings/header_decoder_pydoc_template.h
+++ b/python/bindings/docstrings/header_decoder_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_header_decoder = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_header_decoder_header_decoder = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_header_decoder_make = R"doc()doc";

--- a/python/bindings/docstrings/header_pydoc_template.h
+++ b/python/bindings/docstrings/header_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_header = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_header_header = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_header_make = R"doc()doc";

--- a/python/bindings/docstrings/hier_rx_pydoc_template.h
+++ b/python/bindings/docstrings/hier_rx_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_hier_rx = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_hier_rx_hier_rx = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_hier_rx_make = R"doc()doc";

--- a/python/bindings/docstrings/hier_tx_pydoc_template.h
+++ b/python/bindings/docstrings/hier_tx_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_hier_tx = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_hier_tx_hier_tx = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_hier_tx_make = R"doc()doc";

--- a/python/bindings/docstrings/interleaver_pydoc_template.h
+++ b/python/bindings/docstrings/interleaver_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_interleaver = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_interleaver_interleaver = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_interleaver_make = R"doc()doc";

--- a/python/bindings/docstrings/modulate_pydoc_template.h
+++ b/python/bindings/docstrings/modulate_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_modulate = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_modulate_modulate = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_modulate_make = R"doc()doc";

--- a/python/bindings/docstrings/mu_detection_pydoc_template.h
+++ b/python/bindings/docstrings/mu_detection_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_mu_detection = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_mu_detection_mu_detection = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_mu_detection_make = R"doc()doc";

--- a/python/bindings/docstrings/mu_synchro_pydoc_template.h
+++ b/python/bindings/docstrings/mu_synchro_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_mu_synchro = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_mu_synchro_mu_synchro = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_mu_synchro_make = R"doc()doc";

--- a/python/bindings/docstrings/noise_est_pydoc_template.h
+++ b/python/bindings/docstrings/noise_est_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_noise_est = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_noise_est_noise_est = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_noise_est_make = R"doc()doc";

--- a/python/bindings/docstrings/partial_ml_pydoc_template.h
+++ b/python/bindings/docstrings/partial_ml_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_partial_ml = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_partial_ml_partial_ml = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_partial_ml_make = R"doc()doc";

--- a/python/bindings/docstrings/signal_detector_pydoc_template.h
+++ b/python/bindings/docstrings/signal_detector_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_signal_detector = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_signal_detector_signal_detector = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_signal_detector_make = R"doc()doc";

--- a/python/bindings/docstrings/whitening_pydoc_template.h
+++ b/python/bindings/docstrings/whitening_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,6 +17,9 @@
 
  
  static const char *__doc_gr_lora_sdr_whitening = R"doc()doc";
+
+
+ static const char *__doc_gr_lora_sdr_whitening_whitening = R"doc()doc";
 
 
  static const char *__doc_gr_lora_sdr_whitening_make = R"doc()doc";

--- a/python/bindings/err_measures_python.cc
+++ b/python/bindings/err_measures_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_err_measures(py::module& m)
 {
 
-    using err_measures    = gr::lora_sdr::err_measures;
+    using err_measures    = ::gr::lora_sdr::err_measures;
 
 
-    py::class_<err_measures,
+    py::class_<err_measures, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<err_measures>>(m, "err_measures", D(err_measures))
 
         .def(py::init(&err_measures::make),

--- a/python/bindings/fft_demod_python.cc
+++ b/python/bindings/fft_demod_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_fft_demod(py::module& m)
 {
 
-    using fft_demod    = gr::lora_sdr::fft_demod;
+    using fft_demod    = ::gr::lora_sdr::fft_demod;
 
 
-    py::class_<fft_demod,
+    py::class_<fft_demod, gr::block, gr::basic_block,
         std::shared_ptr<fft_demod>>(m, "fft_demod", D(fft_demod))
 
         .def(py::init(&fft_demod::make),

--- a/python/bindings/frame_detector_sequence_python.cc
+++ b/python/bindings/frame_detector_sequence_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_frame_detector_sequence(py::module& m)
 {
 
-    using frame_detector_sequence    = gr::lora_sdr::frame_detector_sequence;
+    using frame_detector_sequence    = ::gr::lora_sdr::frame_detector_sequence;
 
 
-    py::class_<frame_detector_sequence,
+    py::class_<frame_detector_sequence, gr::block, gr::basic_block,
         std::shared_ptr<frame_detector_sequence>>(m, "frame_detector_sequence", D(frame_detector_sequence))
 
         .def(py::init(&frame_detector_sequence::make),

--- a/python/bindings/frame_detector_threshold_python.cc
+++ b/python/bindings/frame_detector_threshold_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_frame_detector_threshold(py::module& m)
 {
 
-    using frame_detector_threshold    = gr::lora_sdr::frame_detector_threshold;
+    using frame_detector_threshold    = ::gr::lora_sdr::frame_detector_threshold;
 
 
-    py::class_<frame_detector_threshold,
+    py::class_<frame_detector_threshold, gr::block, gr::basic_block,
         std::shared_ptr<frame_detector_threshold>>(m, "frame_detector_threshold", D(frame_detector_threshold))
 
         .def(py::init(&frame_detector_threshold::make),

--- a/python/bindings/frame_detector_timeout_python.cc
+++ b/python/bindings/frame_detector_timeout_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_frame_detector_timeout(py::module& m)
 {
 
-    using frame_detector_timeout    = gr::lora_sdr::frame_detector_timeout;
+    using frame_detector_timeout    = ::gr::lora_sdr::frame_detector_timeout;
 
 
-    py::class_<frame_detector_timeout,gr::block,
+    py::class_<frame_detector_timeout, gr::block, gr::basic_block,
         std::shared_ptr<frame_detector_timeout>>(m, "frame_detector_timeout", D(frame_detector_timeout))
 
         .def(py::init(&frame_detector_timeout::make),

--- a/python/bindings/frame_src_python.cc
+++ b/python/bindings/frame_src_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_frame_src(py::module& m)
 {
 
-    using frame_src    = gr::lora_sdr::frame_src;
+    using frame_src    = ::gr::lora_sdr::frame_src;
 
 
-    py::class_<frame_src,
+    py::class_<frame_src, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<frame_src>>(m, "frame_src", D(frame_src))
 
         .def(py::init(&frame_src::make),

--- a/python/bindings/frame_sync_python.cc
+++ b/python/bindings/frame_sync_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_frame_sync(py::module& m)
 {
 
-    using frame_sync    = gr::lora_sdr::frame_sync;
+    using frame_sync    = ::gr::lora_sdr::frame_sync;
 
 
-    py::class_<frame_sync,
+    py::class_<frame_sync, gr::block, gr::basic_block,
         std::shared_ptr<frame_sync>>(m, "frame_sync", D(frame_sync))
 
         .def(py::init(&frame_sync::make),

--- a/python/bindings/gray_decode_python.cc
+++ b/python/bindings/gray_decode_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_gray_decode(py::module& m)
 {
 
-    using gray_decode    = gr::lora_sdr::gray_decode;
+    using gray_decode    = ::gr::lora_sdr::gray_decode;
 
 
-    py::class_<gray_decode,
+    py::class_<gray_decode, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<gray_decode>>(m, "gray_decode", D(gray_decode))
 
         .def(py::init(&gray_decode::make),

--- a/python/bindings/gray_enc_python.cc
+++ b/python/bindings/gray_enc_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_gray_enc(py::module& m)
 {
 
-    using gray_enc    = gr::lora_sdr::gray_enc;
+    using gray_enc    = ::gr::lora_sdr::gray_enc;
 
 
-    py::class_<gray_enc,
+    py::class_<gray_enc, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<gray_enc>>(m, "gray_enc", D(gray_enc))
 
         .def(py::init(&gray_enc::make),

--- a/python/bindings/hamming_dec_python.cc
+++ b/python/bindings/hamming_dec_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_hamming_dec(py::module& m)
 {
 
-    using hamming_dec    = gr::lora_sdr::hamming_dec;
+    using hamming_dec    = ::gr::lora_sdr::hamming_dec;
 
 
-    py::class_<hamming_dec,
+    py::class_<hamming_dec, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<hamming_dec>>(m, "hamming_dec", D(hamming_dec))
 
         .def(py::init(&hamming_dec::make),

--- a/python/bindings/hamming_enc_python.cc
+++ b/python/bindings/hamming_enc_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_hamming_enc(py::module& m)
 {
 
-    using hamming_enc    = gr::lora_sdr::hamming_enc;
+    using hamming_enc    = ::gr::lora_sdr::hamming_enc;
 
 
-    py::class_<hamming_enc,
+    py::class_<hamming_enc, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<hamming_enc>>(m, "hamming_enc", D(hamming_enc))
 
         .def(py::init(&hamming_enc::make),

--- a/python/bindings/header_decoder_python.cc
+++ b/python/bindings/header_decoder_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_header_decoder(py::module& m)
 {
 
-    using header_decoder    = gr::lora_sdr::header_decoder;
+    using header_decoder    = ::gr::lora_sdr::header_decoder;
 
 
-    py::class_<header_decoder,
+    py::class_<header_decoder, gr::block, gr::basic_block,
         std::shared_ptr<header_decoder>>(m, "header_decoder", D(header_decoder))
 
         .def(py::init(&header_decoder::make),

--- a/python/bindings/header_python.cc
+++ b/python/bindings/header_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_header(py::module& m)
 {
 
-    using header    = gr::lora_sdr::header;
+    using header    = ::gr::lora_sdr::header;
 
 
-    py::class_<header,
+    py::class_<header, gr::block, gr::basic_block,
         std::shared_ptr<header>>(m, "header", D(header))
 
         .def(py::init(&header::make),

--- a/python/bindings/header_utils.py
+++ b/python/bindings/header_utils.py
@@ -6,7 +6,7 @@ import re
 
 class PybindHeaderParser:
     def __init__(self, pathname):
-        with open(pathname,'r') as f:
+        with open(pathname, 'r') as f:
             self.file_txt = f.read()
 
     def get_flag_automatic(self):
@@ -17,8 +17,8 @@ class PybindHeaderParser:
             return True
         else:
             return False
-        
-    def get_flag_pygccxml(self):    
+
+    def get_flag_pygccxml(self):
         # p = re.compile(r'BINDTOOL_USE_PYGCCXML\(([^\s])\)')
         # m = p.search(self.file_txt)
         m = re.search(r'BINDTOOL_USE_PYGCCXML\(([^\s])\)', self.file_txt)
@@ -49,16 +49,18 @@ class PybindHeaderParser:
         return f'{self.get_flag_automatic()};{self.get_flag_pygccxml()};{self.get_header_filename()};{self.get_header_file_hash()};'
 
 
-
 def argParse():
     """Parses commandline args."""
-    desc='Reads the parameters from the comment block in the pybind files'
+    desc = 'Reads the parameters from the comment block in the pybind files'
     parser = ArgumentParser(description=desc)
-    
-    parser.add_argument("function", help="Operation to perform on comment block of pybind file", choices=["flag_auto","flag_pygccxml","header_filename","header_file_hash","all"])
-    parser.add_argument("pathname", help="Pathname of pybind c++ file to read, e.g. blockname_python.cc")
+
+    parser.add_argument("function", help="Operation to perform on comment block of pybind file", choices=[
+                        "flag_auto", "flag_pygccxml", "header_filename", "header_file_hash", "all"])
+    parser.add_argument(
+        "pathname", help="Pathname of pybind c++ file to read, e.g. blockname_python.cc")
 
     return parser.parse_args()
+
 
 if __name__ == "__main__":
     # Parse command line options and set up doxyxml.
@@ -73,6 +75,6 @@ if __name__ == "__main__":
     elif args.function == "header_filename":
         print(pbhp.get_header_filename())
     elif args.function == "header_file_hash":
-        print(pbhp.get_header_file_hash()) 
+        print(pbhp.get_header_file_hash())
     elif args.function == "all":
         print(pbhp.get_flags())

--- a/python/bindings/hier_rx_python.cc
+++ b/python/bindings/hier_rx_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_hier_rx(py::module& m)
 {
 
-    using hier_rx    = gr::lora_sdr::hier_rx;
+    using hier_rx    = ::gr::lora_sdr::hier_rx;
 
 
-    py::class_<hier_rx,gr::hier_block2,
+    py::class_<hier_rx, gr::hier_block2,
         std::shared_ptr<hier_rx>>(m, "hier_rx", D(hier_rx))
 
         .def(py::init(&hier_rx::make),

--- a/python/bindings/hier_tx_python.cc
+++ b/python/bindings/hier_tx_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_hier_tx(py::module& m)
 {
 
-    using hier_tx    = gr::lora_sdr::hier_tx;
+    using hier_tx    = ::gr::lora_sdr::hier_tx;
 
 
-    py::class_<hier_tx,gr::hier_block2,
+    py::class_<hier_tx, gr::hier_block2,
         std::shared_ptr<hier_tx>>(m, "hier_tx", D(hier_tx))
 
         .def(py::init(&hier_tx::make),

--- a/python/bindings/interleaver_python.cc
+++ b/python/bindings/interleaver_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_interleaver(py::module& m)
 {
 
-    using interleaver    = gr::lora_sdr::interleaver;
+    using interleaver    = ::gr::lora_sdr::interleaver;
 
 
-    py::class_<interleaver,
+    py::class_<interleaver, gr::block, gr::basic_block,
         std::shared_ptr<interleaver>>(m, "interleaver", D(interleaver))
 
         .def(py::init(&interleaver::make),

--- a/python/bindings/modulate_python.cc
+++ b/python/bindings/modulate_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_modulate(py::module& m)
 {
 
-    using modulate    = gr::lora_sdr::modulate;
+    using modulate    = ::gr::lora_sdr::modulate;
 
 
-    py::class_<modulate,
+    py::class_<modulate, gr::block, gr::basic_block,
         std::shared_ptr<modulate>>(m, "modulate", D(modulate))
 
         .def(py::init(&modulate::make),

--- a/python/bindings/mu_detection_python.cc
+++ b/python/bindings/mu_detection_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_mu_detection(py::module& m)
 {
 
-    using mu_detection    = gr::lora_sdr::mu_detection;
+    using mu_detection    = ::gr::lora_sdr::mu_detection;
 
 
-    py::class_<mu_detection,
+    py::class_<mu_detection, gr::block, gr::basic_block,
         std::shared_ptr<mu_detection>>(m, "mu_detection", D(mu_detection))
 
         .def(py::init(&mu_detection::make),

--- a/python/bindings/mu_synchro_python.cc
+++ b/python/bindings/mu_synchro_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_mu_synchro(py::module& m)
 {
 
-    using mu_synchro    = gr::lora_sdr::mu_synchro;
+    using mu_synchro    = ::gr::lora_sdr::mu_synchro;
 
 
-    py::class_<mu_synchro,
+    py::class_<mu_synchro, gr::block, gr::basic_block,
         std::shared_ptr<mu_synchro>>(m, "mu_synchro", D(mu_synchro))
 
         .def(py::init(&mu_synchro::make),

--- a/python/bindings/noise_est_python.cc
+++ b/python/bindings/noise_est_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_noise_est(py::module& m)
 {
 
-    using noise_est    = gr::lora_sdr::noise_est;
+    using noise_est    = ::gr::lora_sdr::noise_est;
 
 
-    py::class_<noise_est,
+    py::class_<noise_est, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<noise_est>>(m, "noise_est", D(noise_est))
 
         .def(py::init(&noise_est::make),

--- a/python/bindings/partial_ml_python.cc
+++ b/python/bindings/partial_ml_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_partial_ml(py::module& m)
 {
 
-    using partial_ml    = gr::lora_sdr::partial_ml;
+    using partial_ml    = ::gr::lora_sdr::partial_ml;
 
 
-    py::class_<partial_ml,
+    py::class_<partial_ml, gr::block, gr::basic_block,
         std::shared_ptr<partial_ml>>(m, "partial_ml", D(partial_ml))
 
         .def(py::init(&partial_ml::make),

--- a/python/bindings/python_bindings.cc
+++ b/python/bindings/python_bindings.cc
@@ -43,6 +43,7 @@ namespace py = pybind11;
     void bind_hier_rx(py::module& m);
     void bind_hier_tx(py::module& m);
     void bind_interleaver(py::module& m);
+    void bind_modulate(py::module& m);
     void bind_RH_RF95_header(py::module& m);
     void bind_signal_detector(py::module& m);
     void bind_whitening(py::module& m);
@@ -96,6 +97,7 @@ PYBIND11_MODULE(lora_sdr_python, m)
         bind_hier_rx( m);
         bind_hier_tx( m);
         bind_interleaver( m);
+        bind_modulate( m);
         bind_RH_RF95_header( m);
         bind_signal_detector( m);
         bind_whitening( m);

--- a/python/bindings/signal_detector_python.cc
+++ b/python/bindings/signal_detector_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_signal_detector(py::module& m)
 {
 
-    using signal_detector    = gr::lora_sdr::signal_detector;
+    using signal_detector    = ::gr::lora_sdr::signal_detector;
 
 
-    py::class_<signal_detector,
+    py::class_<signal_detector, gr::block, gr::basic_block,
         std::shared_ptr<signal_detector>>(m, "signal_detector", D(signal_detector))
 
         .def(py::init(&signal_detector::make),

--- a/python/bindings/whitening_python.cc
+++ b/python/bindings/whitening_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -30,10 +30,10 @@ namespace py = pybind11;
 void bind_whitening(py::module& m)
 {
 
-    using whitening    = gr::lora_sdr::whitening;
+    using whitening    = ::gr::lora_sdr::whitening;
 
 
-    py::class_<whitening,
+    py::class_<whitening, gr::sync_block, gr::block, gr::basic_block,
         std::shared_ptr<whitening>>(m, "whitening", D(whitening))
 
         .def(py::init(&whitening::make),


### PR DESCRIPTION
These changes provide support for gnuradio >3.10. The bindings for Python were non functional. Several test files will need updating, but those are left out from this commit.